### PR TITLE
Fix all compilation and test warnings

### DIFF
--- a/test/grpc_test.exs
+++ b/test/grpc_test.exs
@@ -19,8 +19,7 @@ defmodule Ratatoskr.GrpcTest do
     PublishBatchResponse,
     SubscribeRequest,
     UnsubscribeRequest,
-    UnsubscribeResponse,
-    Message
+    UnsubscribeResponse
   }
 
   setup do

--- a/test/recovery_test.exs
+++ b/test/recovery_test.exs
@@ -22,7 +22,7 @@ defmodule Ratatoskr.RecoveryTest do
 
       # Create topic and establish baseline
       {:ok, _topic} = Ratatoskr.create_topic(topic_name)
-      {:ok, ref} = Ratatoskr.subscribe(topic_name)
+      {:ok, _ref} = Ratatoskr.subscribe(topic_name)
 
       # Verify topic is working
       {:ok, _} = Ratatoskr.publish(topic_name, %{before: "crash"})
@@ -58,7 +58,7 @@ defmodule Ratatoskr.RecoveryTest do
       assert new_topic_pid != topic_pid
 
       # Should be functional again
-      {:ok, new_ref} = Ratatoskr.subscribe(topic_name)
+      {:ok, _new_ref} = Ratatoskr.subscribe(topic_name)
       {:ok, _} = Ratatoskr.publish(topic_name, %{after: "recovery"})
       assert_receive {:message, message}, 1000
       assert message.payload.after == "recovery"
@@ -166,8 +166,8 @@ defmodule Ratatoskr.RecoveryTest do
       # Create multiple subscriber processes that will crash
       subscriber_count = 10
 
-      crash_subscribers =
-        for i <- 1..subscriber_count do
+      _crash_subscribers =
+        for _i <- 1..subscriber_count do
           spawn_link(fn ->
             {:ok, _ref} = Ratatoskr.subscribe(topic_name)
 
@@ -181,7 +181,7 @@ defmodule Ratatoskr.RecoveryTest do
         end
 
       # Create one healthy subscriber to verify topic still works
-      healthy_subscriber =
+      _healthy_subscriber =
         spawn_link(fn ->
           {:ok, _ref} = Ratatoskr.subscribe(topic_name)
 
@@ -239,7 +239,7 @@ defmodule Ratatoskr.RecoveryTest do
       {:ok, _topic} = Ratatoskr.create_topic(topic_name)
 
       # Create subscriber that processes slowly
-      slow_subscriber =
+      _slow_subscriber =
         spawn_link(fn ->
           {:ok, _ref} = Ratatoskr.subscribe(topic_name)
           process_messages_slowly(0)
@@ -307,7 +307,7 @@ defmodule Ratatoskr.RecoveryTest do
       # Start background publishers
       publisher_count = 5
 
-      publishers =
+      _publishers =
         for i <- 1..publisher_count do
           spawn_link(fn ->
             # 200 messages each
@@ -318,8 +318,8 @@ defmodule Ratatoskr.RecoveryTest do
       # Start background subscribers  
       subscriber_count = 10
 
-      subscribers =
-        for i <- 1..subscriber_count do
+      _subscribers =
+        for _i <- 1..subscriber_count do
           spawn_link(fn ->
             {:ok, _ref} = Ratatoskr.subscribe(topic_name)
             # Expect to receive messages

--- a/test/stress_test.exs
+++ b/test/stress_test.exs
@@ -91,7 +91,7 @@ defmodule Ratatoskr.StressTest do
       expected_total = publisher_count * messages_per_publisher
 
       # Spawn concurrent publishers
-      {time_ms, publisher_pids} =
+      {time_ms, _publisher_pids} =
         :timer.tc(fn ->
           for i <- 1..publisher_count do
             spawn_link(fn ->
@@ -157,7 +157,7 @@ defmodule Ratatoskr.StressTest do
                    {:ok, _} = Ratatoskr.create_topic(topic)
 
                    # Spawn subscribers for this topic
-                   for i <- 1..subscribers_per_topic do
+                   for _i <- 1..subscribers_per_topic do
                      spawn_link(fn ->
                        {:ok, _ref} = Ratatoskr.subscribe(topic)
                        # Receive messages
@@ -229,8 +229,8 @@ defmodule Ratatoskr.StressTest do
 
       for cycle <- 1..churn_cycles do
         # Connect subscribers
-        subscribers =
-          for i <- 1..subscribers_per_cycle do
+        _subscribers =
+          for _i <- 1..subscribers_per_cycle do
             spawn_link(fn ->
               {:ok, ref} = Ratatoskr.subscribe(topic_name)
 

--- a/test/topic_test.exs
+++ b/test/topic_test.exs
@@ -32,7 +32,7 @@ defmodule Ratatoskr.TopicTest do
 
     test "subscribes processes and receives messages", %{topic_name: topic_name} do
       # Subscribe to the topic
-      assert {:ok, subscription_ref} = TopicServer.subscribe(topic_name, self())
+      assert {:ok, _subscription_ref} = TopicServer.subscribe(topic_name, self())
 
       # Publish a message
       payload = %{data: "test message"}


### PR DESCRIPTION
## Summary
- Fix 13 compilation and test warnings across the test suite
- Prefix unused variables with underscore following Elixir conventions
- Remove unused alias to clean up imports

## Changes
- **recovery_test.exs**: 7 unused variable warnings fixed
- **stress_test.exs**: 4 unused variable warnings fixed  
- **topic_test.exs**: 1 unused variable warning fixed
- **grpc_test.exs**: 1 unused alias warning fixed

## Test plan
- [x] All tests pass: `mix test`
- [x] Compilation passes with warnings as errors: `mix compile --warnings-as-errors`
- [x] Code formatting verified: `mix format`

🤖 Generated with [Claude Code](https://claude.ai/code)